### PR TITLE
Save the metadata monitor from leaving

### DIFF
--- a/shout_errors.py
+++ b/shout_errors.py
@@ -8,3 +8,5 @@ class NoVoiceClient(Exception):
   pass
 class AlreadyPlaying(Exception):
   pass
+class CleaningUp(Exception):
+  pass


### PR DESCRIPTION
Prevents metadata monitor from crashing if the bot doesn't have the permission to post song updates.
Lays a bit of ground work for cleanup lock out (#20 & #14)

Fixes #22 