### PR TITLE
Add cleanup on state lockup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -589,6 +589,10 @@ async def on_command_error(interaction: discord.Interaction, error):
 
 def is_valid_url(url):
   return validators.url(url)
+  
+def restart_bot():
+    logger.warning("Red Button pushed!")
+    os.execv(sys.executable, ['python'] + sys.argv)
 
 # Find information about the playing station & send that as an embed to the original text channel
 async def send_song_info(guild_id: int):
@@ -839,7 +843,7 @@ async def monitor_metadata():
           logger.warning("Metadata monitor does not have enough information to check, restarting bot!")
           
           # oh shit lets just close the whole fucking bot
-          os.execv(sys.executable, ['python'] + sys.argv)
+          await restart_bot()
           continue
 
         stationinfo = streamscrobbler.get_server_info(url)

--- a/bot.py
+++ b/bot.py
@@ -837,6 +837,8 @@ async def monitor_metadata():
 
         if url is None:
           logger.warning("Metadata monitor does not have enough information to check, restarting bot!")
+          
+          # oh shit lets just close the whole fucking bot
           os.execv(sys.executable, ['python'] + sys.argv)
           continue
 

--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@ import discord
 from discord.ext import commands, tasks
 import asyncio
 import os, datetime
+import sys
 import logging, logging.handlers
 import urllib
 import validators
@@ -109,8 +110,6 @@ async def on_ready():
   logger.info(f"Logged on as {bot.user}")
   logger.info(f"Shard IDS: {bot.shard_ids}")
   logger.info(f"Cluster ID: {bot.cluster_id}")
-
-
 
 ### Custom Checks ###
 
@@ -793,7 +792,7 @@ async def monitor_metadata():
         logger.warning(f"[{guild_id}]: Received health error: {health_error}")
         # Track how many times this error occurred and only handle it if it's the third time
         health_error_counts[health_error] += 1
-        logger.warning(f"[{guild_id}]: {health_error} Has not failed {health_error_counts[health_error]} times")
+        logger.warning(f"[{guild_id}]: {health_error} Has failed {health_error_counts[health_error]} times")
         if health_error_counts[health_error] < 3:
           continue
 
@@ -837,7 +836,8 @@ async def monitor_metadata():
         url = get_state(guild_id, 'current_stream_url')
 
         if url is None:
-          logger.warning("Metadata monitor does not have enough information to check")
+          logger.warning("Metadata monitor does not have enough information to check, restarting bot!")
+          os.execv(sys.executable, ['python'] + sys.argv)
           continue
 
         stationinfo = streamscrobbler.get_server_info(url)


### PR DESCRIPTION
this should fix the bot not being able to recover the state after metadata monitor gets stuck while clearing state

(turns bot off and back on again in event of a critical state)